### PR TITLE
feat: Remember cursor's max position

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -515,7 +515,20 @@ impl Editor {
             0
         };
 
-        if (key != Key::Down && key != Key::Up) || self.max_position.is_none() {
+        let is_vertical_control = |k: Key| {
+            match k {
+                Key::Up | Key::Down | Key::Ctrl('f') | Key::Ctrl('b') | Key::Home | Key::End => true,
+                _ => false
+            }
+        };
+        let is_horizontal_control = |k: Key| {
+            match k {
+                Key::Left | Key::Right | Key::Ctrl('a') | Key::Ctrl('e') => true,
+                _ => false
+            }
+        };
+
+        if !is_vertical_control(key) || self.max_position.is_none() {
             x = x.min(width);
         } else if let Some(pos) = self.max_position {
             x = x.max(pos.x).min(width);
@@ -523,8 +536,8 @@ impl Editor {
 
         self.cursor_position = Position { x, y };
 
-        if key == Key::Left || key == Key::Right {
-            // If x position has changed, we need to update the max_position
+        if is_horizontal_control(key) {
+            // We need to update the cursor's max_position iff the keypress controls the cursor's x position
             self.max_position = Some(Position { x, y });
         }
     }


### PR DESCRIPTION
# Summary

This PR adds logic to the editor that remembers the maximum horizontal position of the cursor. When the user navigates the cursor upwards or downwards, the cursor's horizontal position should 

# Example
Suppose the user navigates downward through the following text (`|` indicates the cursor's position).
<img width="145" alt="Screen Shot 2022-08-12 at 4 46 12 PM" src="https://user-images.githubusercontent.com/8460853/184457503-516c7273-416d-4cfb-9d44-6646eb3c6ab7.png">

After pressing the down key once:
<img width="143" alt="Screen Shot 2022-08-12 at 4 46 25 PM" src="https://user-images.githubusercontent.com/8460853/184457519-a52c43ab-44ac-473e-bc2e-e0d9ceff48aa.png">

After pressing the down key again:
<img width="146" alt="Screen Shot 2022-08-12 at 4 46 39 PM" src="https://user-images.githubusercontent.com/8460853/184457531-1f1ebb57-f0a1-4179-b8df-2b1d47250cd4.png">

Note that on the third line, the cursor ends up back where it started horizontally on the first line. Before, the cursor would end up at the same position as it was in the second line.

# Related issue 
Closes #1 