### PR TITLE
feat: Implement word-level navigation

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -233,6 +233,26 @@ impl Document {
         None
     }
 
+    pub fn find_next_word(&self, at: &Position) -> Option<Position> {
+        if at.y >= self.rows.len() {
+            return None;
+        }
+
+        let y = at.y;
+        if let Some(x) = self.rows[y].find_word(at.x) {
+            Some(Position { x, y })
+        } else if y.saturating_add(1) < self.rows.len() {
+            let y_next = y.saturating_add(1);
+            if self.rows[y_next].get_leading_spaces().is_none() {
+                Some(Position { x: 0, y: y_next })
+            } else {
+                self.find_next_word(&Position { x: 0, y: y_next })
+            }
+        } else {
+            None
+        }
+    }
+
     /// Computes the highlight of all rows in the document.
     /// 
     /// # Arguments

--- a/src/document.rs
+++ b/src/document.rs
@@ -233,21 +233,36 @@ impl Document {
         None
     }
 
-    pub fn find_next_word(&self, at: &Position) -> Option<Position> {
+    /// Finds the position of the next word in the document.
+    /// 
+    /// A word is defined as a sequence of alphanumeric characters.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `at` - the position to start looking from
+    /// * `direction` - the [SearchDirection] to use
+    pub fn find_next_word(&self, at: &Position, direction: SearchDirection) -> Option<Position> {
         if at.y >= self.rows.len() {
             return None;
         }
 
         let y = at.y;
-        if let Some(x) = self.rows[y].find_next_word(at.x) {
+        let y_next = if direction == SearchDirection::Forward {
+            y.saturating_add(1)
+        } else {
+            y.saturating_sub(1)
+        };
+
+        let x_next = if direction == SearchDirection::Forward {
+            0
+        } else {
+            self.rows[y_next].len()
+        };
+
+        if let Some(x) = self.rows[y].find_next_word(at.x, direction) {
             Some(Position { x, y })
-        } else if y.saturating_add(1) < self.rows.len() {
-            let y_next = y.saturating_add(1);
-            if self.rows[y_next].get_leading_spaces().is_none() {
-                Some(Position { x: 0, y: y_next })
-            } else {
-                self.find_next_word(&Position { x: 0, y: y_next })
-            }
+        } else if y_next < self.rows.len() && (direction == SearchDirection::Forward || y > 0) {
+            Some(Position { x: x_next, y: y_next })
         } else {
             None
         }
@@ -429,5 +444,29 @@ mod test {
         assert_eq!(text_matches, doc_matches);
         assert!(doc.find(query, &Position { x: 0, y: 0 }, SearchDirection::Forward).is_none());
         assert_eq!(text_after_delete, doc_after_delete);
+    }
+
+    #[test]
+    fn find_next_word() {
+        let mut document = Document::default();
+        document.rows = vec![Row::from("Foo Bar"), Row::from("Hello, World!")];
+
+        let mut position = Position { x: 0, y: 0 };
+        let mut next_position_opt = document.find_next_word(&position, SearchDirection::Backward);
+        assert_eq!(next_position_opt, None);
+
+        next_position_opt = document.find_next_word(&position, SearchDirection::Forward);
+        assert_eq!(next_position_opt, Some(Position { x: 4, y: 0 }));
+        position = next_position_opt.unwrap();
+        
+        next_position_opt = document.find_next_word(&position, SearchDirection::Forward);
+        assert_eq!(next_position_opt, Some(Position { x: 0, y: 1 }));
+        position = next_position_opt.unwrap();
+        
+        next_position_opt = document.find_next_word(&position, SearchDirection::Backward);
+        assert_eq!(next_position_opt, Some(Position { x: 7, y: 0 }));
+        
+        next_position_opt = document.find_next_word(&position, SearchDirection::Forward);
+        assert_eq!(next_position_opt, Some(Position { x: 7, y: 1 }));
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -239,7 +239,7 @@ impl Document {
         }
 
         let y = at.y;
-        if let Some(x) = self.rows[y].find_word(at.x) {
+        if let Some(x) = self.rows[y].find_next_word(at.x) {
             Some(Position { x, y })
         } else if y.saturating_add(1) < self.rows.len() {
             let y_next = y.saturating_add(1);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -37,7 +37,7 @@ pub enum SearchDirection {
 }
 
 /// A position represented by (x, y) coordinates.
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, PartialEq, Debug)]
 pub struct Position {
     pub x: usize,
     pub y: usize,
@@ -600,8 +600,15 @@ impl Editor {
                     x = 0;
                 }
             }
+            WORD_LEFT => {
+                if let Some(pos) = self.document.find_next_word(&self.cursor_position, SearchDirection::Backward)
+                {
+                    x = pos.x;
+                    y = pos.y;
+                }
+            }
             WORD_RIGHT => {
-                if let Some(pos) = self.document.find_next_word(&self.cursor_position)
+                if let Some(pos) = self.document.find_next_word(&self.cursor_position, SearchDirection::Forward)
                 {
                     x = pos.x;
                     y = pos.y;

--- a/src/filetype.rs
+++ b/src/filetype.rs
@@ -219,3 +219,16 @@ impl FileType {
         &self.hl_opts
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::FileType;
+
+    #[test]
+    fn test_filetypes() {
+        assert_eq!(FileType::from("a.rs").name, "Rust");
+        assert_eq!(FileType::from("a.java").name, "Java");
+        assert_eq!(FileType::from("a.txt").name, "No filetype");
+        assert_eq!(FileType::from("foo").name, "No filetype");
+    }
+}

--- a/src/row.rs
+++ b/src/row.rs
@@ -219,28 +219,32 @@ impl Row {
         None
     }
 
-    pub fn find_word(&self, at: usize) -> Option<usize> {
-        if at >= self.len() {
+    pub fn find_next_word(&self, start: usize) -> Option<usize> {
+        if start >= self.len() {
             return None;
         }
 
         let substring: String = self.string[..]
             .graphemes(true)
-            .skip(at)
+            .skip(start)
             .collect();
 
+        let mut x_skip = 0;
         if substring.chars().nth(0).unwrap().is_alphanumeric() {
-            if let Some(x) = substring.find(is_separator) {
-                self.find_word(x + at)
+            // If the cursor is currently on a word, we need to find the next separator
+            // character before we can find the next word.
+            if let Some(sep_idx) = substring.find(is_separator) {
+                x_skip = sep_idx;
             } else {
-                None
+                return None;
             }
+        }
+
+        // Look for the next alphanumeric character, which is the start of the next word.
+        if let Some(x) = substring[x_skip..].find(|c: char| c.is_alphanumeric()) {
+            Some(x.saturating_add(start).saturating_add(x_skip))
         } else {
-            if let Some(x) = substring.find(|c: char| c.is_alphanumeric()) {
-                Some(x + at)
-            } else {
-                None
-            }
+            None
         }
     }
 

--- a/src/row.rs
+++ b/src/row.rs
@@ -219,6 +219,31 @@ impl Row {
         None
     }
 
+    pub fn find_word(&self, at: usize) -> Option<usize> {
+        if at >= self.len() {
+            return None;
+        }
+
+        let substring: String = self.string[..]
+            .graphemes(true)
+            .skip(at)
+            .collect();
+
+        if substring.chars().nth(0).unwrap().is_alphanumeric() {
+            if let Some(x) = substring.find(is_separator) {
+                self.find_word(x + at)
+            } else {
+                None
+            }
+        } else {
+            if let Some(x) = substring.find(|c: char| c.is_alphanumeric()) {
+                Some(x + at)
+            } else {
+                None
+            }
+        }
+    }
+
     /// Replaces all selections made in the row.
     /// 
     /// # Arguments


### PR DESCRIPTION
# Summary

This PR implements vim-like word-level navigation to the editor. A word here is defined as a sequence of alphanumeric characters. In addition, this PR changes the keybindings for navigation to use the Alt key rather than the Ctrl key.

#### Attached issue

Closes #2 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes and have added any tests as needed.
- [x] I have added comments in hard-to-understand areas.
- [x] I have made any necessary changes to documentation.
