### PR TITLE
feat: Syntax highlighting for Python

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -275,7 +275,7 @@ impl Document {
     /// * `word` - the word to highlight, if any
     /// * `until` - the index to stop highlighting at
     pub fn highlight(&mut self, word: &Option<String>, until: Option<usize>) {
-        let mut start_with_comment = false;
+        let mut look_for_multiline_close = None;
         let until = if let Some(until) = until {
             if until.saturating_add(1) < self.rows.len() {
                 until.saturating_add(1)
@@ -286,10 +286,10 @@ impl Document {
             self.rows.len()
         };
         for row in &mut self.rows[..until] {
-            start_with_comment = row.highlight(
+            row.highlight(
                 self.file_type.highlighting_options(),
                 word,
-                start_with_comment,
+                &mut look_for_multiline_close,
             );
         }
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -458,7 +458,6 @@ impl Editor {
                     Key::Backspace => result.truncate(result.len().saturating_sub(1)),
                     Key::Char('\n') => {
                         self.document.reset_selections();
-                        result = "\0".to_string();
                         break;
                     }
                     Key::Char(c) => {
@@ -468,7 +467,6 @@ impl Editor {
                     }
                     Key::Ctrl('d') => {
                         self.document.delete_selections();
-                        result = "\0".to_string();
                         break;
                     }
                     Key::Ctrl('r') => {
@@ -478,7 +476,6 @@ impl Editor {
                         } else {
                             self.document.reset_selections();
                         }
-                        result = "\0".to_string();
                         break;
                     }
                     Key::Esc => {

--- a/src/filetype.rs
+++ b/src/filetype.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 /// The file type of a document.
 pub struct FileType {
     /// The type associated with this [FileType] (e.g. "Rust" for ".rs" files)
@@ -13,7 +15,7 @@ pub struct HighlightingOptions {
     strings: bool,
     characters: bool,
     comments: Option<String>,
-    multiline_comments: bool,
+    multiline_comments: Option<HashMap<String, String>>,
     primary_keywords: Vec<String>,
     secondary_keywords: Vec<String>,
 }
@@ -31,8 +33,8 @@ impl HighlightingOptions {
     pub fn comments(&self) -> &Option<String> {
         &self.comments
     }
-    pub fn multiline_comments(&self) -> bool {
-        self.multiline_comments
+    pub fn multiline_comments(&self) -> &Option<HashMap<String, String>> {
+        &self.multiline_comments
     }
     pub fn primary_keywords(&self) -> &Vec<String> {
         &self.primary_keywords
@@ -66,7 +68,9 @@ impl FileType {
                     strings: true,
                     characters: true,
                     comments: Some("//".to_string()),
-                    multiline_comments: true,
+                    multiline_comments: Some(HashMap::from([
+                        ("/*".to_string(), "*/".to_string()),
+                    ])),
                     primary_keywords: vec![
                         "as".to_string(),
                         "break".to_string(),
@@ -146,7 +150,9 @@ impl FileType {
                     strings: true,
                     characters: true,
                     comments: Some("//".to_string()),
-                    multiline_comments: true,
+                    multiline_comments: Some(HashMap::from([
+                        ("/*".to_string(), "*/".to_string()),
+                    ])),
                     primary_keywords: vec![
                         "abstract".to_string(),
                         "assert".to_string(),
@@ -203,7 +209,59 @@ impl FileType {
                         "short".to_string(),
                     ],
                 },
-            };
+            }
+        } else if file_name.ends_with(".py") {
+            return Self {
+                name: String::from("Python"),
+                hl_opts: HighlightingOptions {
+                    numbers: true,
+                    strings: true,
+                    characters: true,
+                    comments: Some("#".to_string()),
+                    multiline_comments: Some(HashMap::from([
+                        ("'''".to_string(), "'''".to_string()),
+                        ("\"\"\"".to_string(), "\"\"\"".to_string()),
+                    ])),
+                    primary_keywords: vec![
+                        "False".to_string(),
+                        "None".to_string(),
+                        "True".to_string(),
+                        "and".to_string(),
+                        "as".to_string(),
+                        "assert".to_string(),
+                        "async".to_string(),
+                        "await".to_string(),
+                        "break".to_string(),
+                        "class".to_string(),
+                        "continue".to_string(),
+                        "def".to_string(),
+                        "del".to_string(),
+                        "elif".to_string(),
+                        "else".to_string(),
+                        "except".to_string(),
+                        "finally".to_string(),
+                        "for".to_string(),
+                        "from".to_string(),
+                        "global".to_string(),
+                        "if".to_string(),
+                        "import".to_string(),
+                        "in".to_string(),
+                        "is".to_string(),
+                        "lambda".to_string(),
+                        "nonlocal".to_string(),
+                        "not".to_string(),
+                        "or".to_string(),
+                        "pass".to_string(),
+                        "raise".to_string(),
+                        "return".to_string(),
+                        "try".to_string(),
+                        "while".to_string(),
+                        "with".to_string(),
+                        "yield".to_string(),
+                    ],
+                    secondary_keywords: vec![],
+                },
+            }
         }
 
         Self::default()

--- a/src/filetype.rs
+++ b/src/filetype.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 /// The file type of a document.
 pub struct FileType {
     /// The type associated with this [FileType] (e.g. "Rust" for ".rs" files)
@@ -12,10 +10,10 @@ pub struct FileType {
 #[derive(Default)]
 pub struct HighlightingOptions {
     numbers: bool,
-    strings: bool,
     characters: bool,
+    strings: Option<Vec<char>>,
     comments: Option<String>,
-    multiline_comments: Option<HashMap<String, String>>,
+    multiline_comments: Option<Vec<(String, String)>>,
     primary_keywords: Vec<String>,
     secondary_keywords: Vec<String>,
 }
@@ -24,16 +22,16 @@ impl HighlightingOptions {
     pub fn numbers(&self) -> bool {
         self.numbers
     }
-    pub fn strings(&self) -> bool {
-        self.strings
-    }
     pub fn characters(&self) -> bool {
         self.characters
+    }
+    pub fn strings(&self) -> &Option<Vec<char>> {
+        &self.strings
     }
     pub fn comments(&self) -> &Option<String> {
         &self.comments
     }
-    pub fn multiline_comments(&self) -> &Option<HashMap<String, String>> {
+    pub fn multiline_comments(&self) -> &Option<Vec<(String, String)>> {
         &self.multiline_comments
     }
     pub fn primary_keywords(&self) -> &Vec<String> {
@@ -65,12 +63,12 @@ impl FileType {
                 name: String::from("Rust"),
                 hl_opts: HighlightingOptions {
                     numbers: true,
-                    strings: true,
                     characters: true,
+                    strings: Some(vec!['"']),
                     comments: Some("//".to_string()),
-                    multiline_comments: Some(HashMap::from([
+                    multiline_comments: Some(vec![
                         ("/*".to_string(), "*/".to_string()),
-                    ])),
+                    ]),
                     primary_keywords: vec![
                         "as".to_string(),
                         "break".to_string(),
@@ -147,12 +145,12 @@ impl FileType {
                 name: String::from("Java"),
                 hl_opts: HighlightingOptions {
                     numbers: true,
-                    strings: true,
                     characters: true,
+                    strings: Some(vec!['"']),
                     comments: Some("//".to_string()),
-                    multiline_comments: Some(HashMap::from([
+                    multiline_comments: Some(vec![
                         ("/*".to_string(), "*/".to_string()),
-                    ])),
+                    ]),
                     primary_keywords: vec![
                         "abstract".to_string(),
                         "assert".to_string(),
@@ -215,13 +213,13 @@ impl FileType {
                 name: String::from("Python"),
                 hl_opts: HighlightingOptions {
                     numbers: true,
-                    strings: true,
-                    characters: true,
+                    characters: false,
+                    strings: Some(vec!['"', '\'']),
                     comments: Some("#".to_string()),
-                    multiline_comments: Some(HashMap::from([
+                    multiline_comments: Some(vec![
                         ("'''".to_string(), "'''".to_string()),
                         ("\"\"\"".to_string(), "\"\"\"".to_string()),
-                    ])),
+                    ]),
                     primary_keywords: vec![
                         "False".to_string(),
                         "None".to_string(),

--- a/src/row.rs
+++ b/src/row.rs
@@ -656,27 +656,31 @@ impl Row {
         c: char,
         chars: &[char],
     ) -> bool {
-        if opts.strings() && c == '"' {
-            let mut prev_char = c;
-            loop {
-                self.highlighting.push(highlighting::Type::String);
-                *index += 1;
-                if let Some(next_char) = chars.get(*index) {
-                    if prev_char != '\\' && *next_char == '"' {
-                        break;
+        if let Some(string_delims) = opts.strings() {
+            for string_delim in string_delims {
+                if c == *string_delim {
+                    let mut prev_char = c;
+                    loop {
+                        self.highlighting.push(highlighting::Type::String);
+                        *index += 1;
+                        if let Some(next_char) = chars.get(*index) {
+                            if prev_char != '\\' && *next_char == *string_delim {
+                                break;
+                            }
+                            prev_char = *next_char;
+                        } else {
+                            break;
+                        }
                     }
-                    prev_char = *next_char;
-                } else {
-                    break;
+        
+                    self.highlighting.push(highlighting::Type::String);
+                    *index += 1;
+                    return true;
                 }
             }
-
-            self.highlighting.push(highlighting::Type::String);
-            *index += 1;
-            true
-        } else {
-            false
         }
+        
+        false
     }
 
     /// Checks whether there is a number literal to be highlighted.

--- a/src/row.rs
+++ b/src/row.rs
@@ -852,7 +852,7 @@ fn is_separator(c: char) -> bool {
 mod test {
     use crate::highlighting::Type;
     use crate::row::Row;
-    use crate::{SearchDirection};
+    use crate::{SearchDirection, FileType};
 
     #[test]
     fn basics() {
@@ -937,8 +937,10 @@ mod test {
     }
 
     #[test]
-    fn highlight() {
+    fn highlight_rust() {
         // TODO: flesh out highlighting unit tests
+        let filetype = FileType::from("foo.rs");
+
         let mut row = Row::from("let foo=3;");
         let mut base = vec![
             Type::PrimaryKeywords, Type::PrimaryKeywords, Type::PrimaryKeywords,    // let
@@ -948,6 +950,8 @@ mod test {
             Type::Number,                                                           // 3
             Type::None                                                              // ;
         ];
+        let mut look_for_multiline_close = None;
+        row.highlight(&filetype.highlighting_options(), &None, &mut look_for_multiline_close);
         assert!(row.highlighting.eq(&base));
 
         row = Row::from("\"a3\"/*3");
@@ -955,6 +959,8 @@ mod test {
             Type::String, Type::String, Type::String, Type::String,                     // "a3"
             Type::MultilineComment, Type::MultilineComment, Type::MultilineComment      // /*3
         ];
+        row.highlight(&filetype.highlighting_options(), &None, &mut look_for_multiline_close);
         assert!(row.highlighting.eq(&base));
+        assert!(look_for_multiline_close == Some("*/".to_string()));
     }
 }

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,6 +1,7 @@
 use crate::highlighting;
 use crate::HighlightingOptions;
 use crate::SearchDirection;
+use crate::highlighting::Type;
 use std::vec;
 use termion::color;
 use unicode_segmentation::UnicodeSegmentation;
@@ -598,27 +599,32 @@ impl Row {
         false
     }
 
-    /// Checks whether there is a multiline comment to be highlighted.
+    /// Checks whether there is a multiline comment to be highlighted in this row. If so,
+    /// this function returns the delimiter that closes the multiline comment.
     /// 
     /// # Arguments
     /// 
     /// * `index` - the index to check from; this gets updated to the end of the highlight
     /// * `opts` - the [HighlightingOptions] to use
-    /// * `c` - the character at `chars[index]`
+    /// * `_` - the character at `chars[index]`
     /// * `chars` - the characters in the row
     pub fn highlight_multiline_comment(
         &mut self,
         index: &mut usize,
         opts: &HighlightingOptions,
-        c: char,
+        _: char,
         chars: &[char],
-    ) -> bool {
-        if opts.multiline_comments() && c == '/' && *index < chars.len() {
-            if let Some(next_char) = chars.get(index.saturating_add(1)) {
-                if *next_char == '*' {
-                    let closing_index =
-                        if let Some(closing_index) = self.string[*index + 2..].find("*/") {
-                            *index + closing_index + 4
+    ) -> Option<String> {
+        if let Some(multiline_comment_delims) = opts.multiline_comments() {
+            for (opening_delim, closing_delim) in multiline_comment_delims {
+                if let Some(k) = self.string[*index..].find(opening_delim) {
+                    if k != 0 {
+                        continue;
+                    }
+
+                    let closing_index = 
+                        if let Some(closing_index) = self.string[*index + opening_delim.len()..].find(closing_delim) {
+                            *index + opening_delim.len() + closing_index + closing_delim.len()
                         } else {
                             chars.len()
                         };
@@ -627,12 +633,12 @@ impl Row {
                         *index += 1;
                     }
 
-                    return true;
+                    return Some(closing_delim.to_string());
                 }
             }
         }
 
-        false
+        None
     }
 
     /// Checks whether there is a string literal to be highlighted.
@@ -714,47 +720,50 @@ impl Row {
         }
     }
 
-    /// Computes the highlighting (if any) of every grapheme in this row. This function returns
-    /// whether a multi-line comment continues into the next line.
+    /// Computes the highlighting (if any) of every grapheme in this row.
     /// 
     /// # Arguments
     /// 
     /// * `opts` - the `HighlightingOptions` to use
     /// * `word` - the word to highlight (if any)
-    /// * `start_with_comment` - whether the start of the row is part of a multi-line comment
+    /// * `look_for_multiline_close` - until this delimiter is found, graphemes are highlighted as a multiline comment.
+    ///     This function changes this accordingly whenever a multiline comment opens or closes.
     pub fn highlight(
         &mut self,
         opts: &HighlightingOptions,
         word: &Option<String>,
-        start_with_comment: bool,
-    ) -> bool {
+        look_for_multiline_close: &mut Option<String>,
+    ) {
         let chars: Vec<char> = self.string.chars().collect();
         if self.is_highlighted && word.is_none() {
-            return false;
+            *look_for_multiline_close = None;
+            return;
         }
 
         self.highlighting = Vec::new();
         let mut index = 0;
-        let mut in_multiline_comment = start_with_comment;
 
-        if in_multiline_comment {
-            let closing_index = if let Some(closing_index) = self.string.find("*/") {
-                closing_index + 2
-            } else {
-                chars.len()
-            };
+        if let Some(closing_delim) = look_for_multiline_close {
+            let closing_index = 
+                if let Some(closing_index) = self.string.find(&String::clone(closing_delim)) {
+                    closing_index + closing_delim.len()
+                } else {
+                    chars.len()
+                };
             for _ in 0..closing_index {
                 self.highlighting.push(highlighting::Type::MultilineComment);
             }
             index = closing_index;
         }
 
+        let mut start_multiline_comment = false;
         while let Some(c) = chars.get(index) {
-            if self.highlight_multiline_comment(&mut index, opts, *c, &chars) {
-                in_multiline_comment = true;
+            if let Some(closing_delim) = self.highlight_multiline_comment(&mut index, opts, *c, &chars) {
+                *look_for_multiline_close = Some(closing_delim);
+                start_multiline_comment = true;
                 continue;
             }
-            in_multiline_comment = false;
+            *look_for_multiline_close = None;
             if self.highlight_char(&mut index, opts, *c, &chars)
                 || self.highlight_comment(&mut index, opts, *c, &chars)
                 || self.highlight_primary_keywords(&mut index, opts, &chars)
@@ -772,12 +781,19 @@ impl Row {
         self.highlight_match(word);
         self.highlight_selection();
 
-        if in_multiline_comment && &self.string[self.string.len().saturating_sub(2)..] != "*/" {
-            return true;
+        if let Some(closing_delim) = look_for_multiline_close {
+            let k = self.string.len().saturating_sub(closing_delim.len());
+            if (k == 0 && start_multiline_comment) ||
+                !matches!(self.highlighting.get(k.saturating_sub(1)), Some(Type::MultilineComment)) ||
+                &self.string[k..] != closing_delim
+            {
+                *look_for_multiline_close = Some(closing_delim.to_string());
+                return;
+            }
         }
 
         self.is_highlighted = true;
-        false
+        *look_for_multiline_close = None;
     }
 
     /// Gets the length of the row.
@@ -832,7 +848,7 @@ fn is_separator(c: char) -> bool {
 mod test {
     use crate::highlighting::Type;
     use crate::row::Row;
-    use crate::{SearchDirection, FileType};
+    use crate::{SearchDirection};
 
     #[test]
     fn basics() {
@@ -919,10 +935,7 @@ mod test {
     #[test]
     fn highlight() {
         // TODO: flesh out highlighting unit tests
-        let filetype = FileType::from("foo.rs");
-
         let mut row = Row::from("let foo=3;");
-        assert!(!row.highlight(&filetype.highlighting_options(), &None, false));
         let mut base = vec![
             Type::PrimaryKeywords, Type::PrimaryKeywords, Type::PrimaryKeywords,    // let
             Type::None,
@@ -934,7 +947,6 @@ mod test {
         assert!(row.highlighting.eq(&base));
 
         row = Row::from("\"a3\"/*3");
-        assert!(row.highlight(&filetype.highlighting_options(), &None, false));
         base = vec![
             Type::String, Type::String, Type::String, Type::String,                     // "a3"
             Type::MultilineComment, Type::MultilineComment, Type::MultilineComment      // /*3


### PR DESCRIPTION
# Summary

DO NOT MERGE: THIS IS STILL IN PROGRESS.

This PR adds syntax highlighting for Python. This required a significant change to the way strings and multiline comments are handled since Python essentially treats single quotes and double quotes the same in these contexts.

#### Attached issue

Closes #4

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes and have added any tests as needed.
- [x] I have added comments in hard-to-understand areas.
- [x] I have made any necessary changes to documentation.

# Screenshots / Examples

<img width="532" alt="Screen Shot 2022-09-06 at 2 00 07 PM" src="https://user-images.githubusercontent.com/8460853/188737095-14ecf91b-22ec-4f16-a71a-8394a31e69fd.png">
